### PR TITLE
Enable decoration by Predicate instance, add `suppressed_errors` kwarg to Predicate

### DIFF
--- a/handpick/core.py
+++ b/handpick/core.py
@@ -73,8 +73,9 @@ class Predicate:
     argument to the `pick` function.
     """
 
-    def __init__(self, func=None):
+    def __init__(self, func=None, suppressed_errors=_ERRORS):
         self.func = func
+        self.suppressed_errors = suppressed_errors
 
     def __call__(self, obj):
         if self.func is None:
@@ -84,7 +85,7 @@ class Predicate:
         try:
             # instance called as predicate
             return self.func(obj)
-        except _ERRORS:
+        except self.suppressed_errors:
             # exception indicates that object does not meet predicate
             return False
 

--- a/handpick/core.py
+++ b/handpick/core.py
@@ -73,11 +73,16 @@ class Predicate:
     argument to the `pick` function.
     """
 
-    def __init__(self, func):
+    def __init__(self, func=None):
         self.func = func
 
     def __call__(self, obj):
+        if self.func is None:
+            # instance called as decorator
+            self.func = obj
+            return self
         try:
+            # instance called as predicate
             return self.func(obj)
         except _ERRORS:
             # exception indicates that object does not meet predicate

--- a/tests/property_based_test.py
+++ b/tests/property_based_test.py
@@ -3,7 +3,9 @@ import string
 from hypothesis import given
 import hypothesis.strategies as st
 
-from handpick import pick, IS_COLLECTION, is_type, not_type
+from handpick import pick, Predicate, IS_COLLECTION, is_type, not_type
+
+from tests import is_even
 
 strings = st.text(string.printable)
 keys = strings
@@ -34,3 +36,10 @@ def test_is_type_not_type(type_, value):
     pred_2 = not_type(type_)
     assert pred_1(value) is (~pred_2)(value)
     assert (~pred_1)(value) is pred_2(value)
+
+
+@given(values)
+def test_predicate_decorator_call(value):
+    pred_1 = Predicate(is_even)
+    pred_2 = Predicate()(is_even)
+    assert pred_1(value) is pred_2(value)

--- a/tests/property_based_test.py
+++ b/tests/property_based_test.py
@@ -43,3 +43,10 @@ def test_predicate_decorator_call(value):
     pred_1 = Predicate(is_even)
     pred_2 = Predicate()(is_even)
     assert pred_1(value) is pred_2(value)
+
+
+@given(values)
+def test_predicate_decorator_call_with_kwarg(value):
+    pred_1 = Predicate(is_even, suppressed_errors=(TypeError, ValueError))
+    pred_2 = Predicate(suppressed_errors=(TypeError, ValueError))(is_even)
+    assert pred_1(value) is pred_2(value)

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -16,14 +16,39 @@ from tests import is_even, is_positive
 
 
 class TestDecoratorUsage:
-    def test_stacked_decorator(self):
-        _is_even = Predicate(Predicate(is_even))
+    def test_decorator(self):
+        """Test `@Predicate` decorator usage."""
+        pred = Predicate(is_even)
+        assert pred.func is is_even
+        assert pred(42) is pred.func(42) is True
+        assert pred(15) is pred.func(15) is False
+        assert pred("A") is False  # suppressed TypeError
+        with pytest.raises(TypeError):
+            pred.func("A")
 
-        assert type(_is_even.func) is Predicate
-        assert type(_is_even.func.func) is not Predicate
-        assert _is_even(42) is _is_even.func(42) is _is_even.func.func(42) is True
-        assert _is_even(15) is _is_even.func(15) is _is_even.func.func(15) is False
-        assert _is_even("A") is _is_even.func("A") is False  # suppressed TypeError
+    def test_decorator_call(self):
+        """Test `@Predicate()` decorator usage."""
+        pred = Predicate()(is_even)
+        assert type(pred) is Predicate
+        assert pred.func is is_even
+        assert pred(42) is pred.func(42) is True
+        assert pred(15) is pred.func(15) is False
+        assert pred("A") is False  # suppressed TypeError
+        with pytest.raises(TypeError):
+            pred.func("A")
+
+    def test_underlying_function_identity(self):
+        from_decorator = Predicate(is_even)
+        from_decorator_call = Predicate()(is_even)
+        assert from_decorator.func is from_decorator_call.func is is_even
+
+    def test_stacked_decorator(self):
+        pred = Predicate(Predicate(is_even))
+        assert type(pred.func) is Predicate
+        assert type(pred.func.func) is not Predicate
+        assert pred(42) is pred.func(42) is pred.func.func(42) is True
+        assert pred(15) is pred.func(15) is pred.func.func(15) is False
+        assert pred("A") is pred.func("A") is False  # suppressed TypeError
 
 
 class TestFromFunctionFactoryMethod:

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -51,6 +51,34 @@ class TestDecoratorUsage:
         assert pred("A") is pred.func("A") is False  # suppressed TypeError
 
 
+class TestErrorHandling:
+    def test_predicate_suppresses_errors_by_default(self):
+        @Predicate
+        def pred(obj):
+            return obj[0] > 0
+
+        assert type(pred) is Predicate
+        assert pred([42]) is pred.func([42]) is True
+        assert pred([-15]) is pred.func([-15]) is False
+        # suppressed IndexError and TypeError
+        assert pred([]) is False
+        assert pred(["A"]) is False
+
+    def test_predicate_propagates_errors_optionally(self):
+        @Predicate(suppressed_errors=())
+        def pred(obj):
+            return obj[0] > 0
+
+        assert type(pred) is Predicate
+        assert pred([42]) is pred.func([42]) is True
+        assert pred([-15]) is pred.func([-15]) is False
+        # propagated IndexError and TypeError
+        with pytest.raises(IndexError):
+            pred([])
+        with pytest.raises(TypeError):
+            pred(["A"])
+
+
 class TestFromFunctionFactoryMethod:
     @pytest.mark.parametrize("class_or_instance", (Predicate, Predicate(is_even)))
     @pytest.mark.parametrize(


### PR DESCRIPTION
Allow customization of which error classes will be suppressed by a predicate. For example:

```python
@Predicate(suppressed_errors=(IndexError,))
def first_item_is_positive(sequence):
    return sequence[0] > 0
```

will suppress IndexError exceptions for empty sequences, but not TypeError exceptions for values that don't support the ` > 0` operation.