### PR TITLE
Update supported Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312,313},pypy{38,39,310},code
+envlist = py{39,310,311,312,313,314},pypy{310,311},code
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Drop support for Python 3.8, PyPy 3.8 and PyPy 3.9.

Add support for Python 3.14 and PyPy 3.11.